### PR TITLE
Add bool function

### DIFF
--- a/src/Bool/Extra.elm
+++ b/src/Bool/Extra.elm
@@ -43,8 +43,8 @@ import Json.Encode as Encode
 
 -}
 toMaybe : a -> Bool -> Maybe a
-toMaybe v bool =
-    if bool then
+toMaybe v pred =
+    if pred then
         Just v
 
     else
@@ -61,8 +61,8 @@ toMaybe v bool =
 
 -}
 toString : Bool -> String
-toString bool =
-    if bool then
+toString pred =
+    if pred then
         "True"
 
     else
@@ -131,8 +131,8 @@ stringDecoder =
         decoderFromString : String -> Decoder Bool
         decoderFromString str =
             case fromString str of
-                Just bool ->
-                    Decode.succeed bool
+                Just pred ->
+                    Decode.succeed pred
 
                 Nothing ->
                     Decode.fail ("string is not \"true\" or \"false\" ->" ++ str)

--- a/src/Bool/Extra.elm
+++ b/src/Bool/Extra.elm
@@ -244,3 +244,14 @@ allPass ps x =
 anyPass : List (a -> Bool) -> a -> Bool
 anyPass ps x =
     List.foldl (\p acc -> acc || p x) False ps
+
+{- | Reorder if-then-else syntax arguments.
+
+     bool 0 1 True
+     --> 1
+
+     bool 0 1 False
+     --> 0
+-}
+bool : a -> a -> Bool -> a
+bool x y p = if p then y else x


### PR DESCRIPTION
Hi,

I've find your repository looking for the neat `bool` function available in [Haskell standard library](http://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Bool.html#v:bool).

I had to rename occurrences of the word `bool` to `pred` for predicate to avoid shadowing errors. If you have a better naming alternative, let me know about it.

Regards,

 